### PR TITLE
fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# TOOLCHAIN=""
-# RUSTFLAGS+=""
+TOOLCHAIN=
+RUSTFLAGS=
 
 ifdef DADK_CURRENT_BUILD_DIR
 # 如果是在dadk中编译，那么安装到dadk的安装目录中

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-TOOLCHAIN=""
-RUSTFLAGS+=""
+# TOOLCHAIN=""
+# RUSTFLAGS+=""
 
 ifdef DADK_CURRENT_BUILD_DIR
 # 如果是在dadk中编译，那么安装到dadk的安装目录中


### PR DESCRIPTION
防止出现
```
RUSTFLAGS="" cargo "" fmt
error: no such command: ``

        Did you mean `b`?

        View all installed commands with `cargo --list`
        Find a package to install `` with `cargo search cargo-`
```